### PR TITLE
fix issue with logging file in 0.11

### DIFF
--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -10,7 +10,7 @@ ENV FLB_VERSION 0.11.14
 
 ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.zip
 
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
 
 RUN apt-get -qq update \
     && apt-get install -y -qq \


### PR DESCRIPTION
fix issue:
[log] error opening log file /fluent-bit/log/fluent-bit.log. Using stderr.