### PR TITLE
fix issue with logging in 0.12

### DIFF
--- a/0.12-dev/Dockerfile
+++ b/0.12-dev/Dockerfile
@@ -10,7 +10,7 @@ ENV FLB_VERSION 0.12.0
 
 ENV FLB_TARBALL http://github.com/fluent/fluent-bit/archive/master.zip
 
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
 
 RUN apt-get -qq update \
     && apt-get install -y -qq \


### PR DESCRIPTION
fix issue with logging file missing:
[log] error opening log file /fluent-bit/log/fluent-bit.log. Using stderr.