### PR TITLE
Update pull request command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker build -t fluent-bit:0.11 ./
 Once the image is built, it's ready to run:
 
 ```
-docker run -p 127.0.0.1:24224:24224 fluent-bit:latest
+docker run -p 127.0.0.1:24224:24224 fluent/fluent-bit:latest
 ```
 
 By default, the configuration set a listener on TCP port 24224 through Forward protocol and prints to the standard output interface each message. So this can be used to forward Docker log messages from one container to the Fluent Bit image, e.g:


### PR DESCRIPTION
without fluent prefix in image name, docker is not able to pull the image
```sh
docker run -d -p 127.0.0.1:24224:24224 fluent-bit:latest
Unable to find image 'fluent-bit:latest' locally
docker: Error response from daemon: repository fluent-bit not found: does not exist or no pull access.
See 'docker run --help'.
```

but if we write `docker run -d -p 127.0.0.1:24224:24224 fluent/fluent-bit:latest` then it is working and able to pull and run the image.

I think because there are many more fluent-bit images with the same name by different users, that's why docker is not able to identify this image.
eg. boxcast/fluent-bit, moeyservices/fluent-bit, kubeup/fluent-bit