### PR TITLE
Fix ca certificate installation

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -14,7 +14,6 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log
 
 RUN apt-get -qq update \
     && apt-get install -y -qq \
-       ca-certificates \
        build-essential \
        cmake \
        make \
@@ -37,6 +36,7 @@ RUN apt-get -qq update \
        bzip2 \
        openssl \
        manpages \
+    && apt-get install -y -qq --no-install-recommends ca-certificates \
     && rm -rf /tmp/*
 
 # Configuration files


### PR DESCRIPTION
The subsequent removal of openssl was removing ca-certificates and
`/etc/ssl`. This causes the tls options to fail on output plugins.

This change rearranges the order to ensure CA certificates will be
present.