### PR TITLE
Update Tags Available

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Fluent Bit Dockerfiles are located in separated branches with proper tags:
 
 | Branch | Tags Available                                               |
 | ------ | ------------------------------------------------------------ |
-| 0.13   | 0.13, 0.13.0                                                 |
+| 1.0    | 1.0, 1.0-debug, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.3-debug, 1.0.4, 1.0.4-debug |
+| 0.14   | 0.14, 0.14.0, 0.14.1, 0.14.2, 0.14.3, 0.14.4, 0.14.5, 0.14.6, 0.14.7, 0.14.8, 0.14.9 |
+| 0.13   | 0.13, 0.13.0, 0.13.1, 0.13.2, 0.13.3, 0.13.4, 0.13.5, 0.13.6, 0.13.7, 0.13.8 |
 | 0.12   | 0.12, 0.12.19, 0.12.18, 0.12.17, 0.12.16, 0.12.15, 0.12.14, 0.12.13, 0.12.12, 0.12.11, 0.12.10, 0.12.9, 0.12.8, 0.12.7, 0.12.6, 0.12.5, 0.12.4, 0.12.3, 0.12.2, 0.12.1, 0.12.0 |
 
 ## 2. Build image
@@ -18,8 +20,8 @@ Fluent Bit Dockerfiles are located in separated branches with proper tags:
 Use `docker build` command to build the image. This example names the image "fluent-bit:latest":
 
 ```
-$ cd 0.13/
-$ docker build -t fluent/fluent-bit:0.13 ./
+$ cd 1.0/
+$ docker build -t fluent/fluent-bit:1.0 ./
 ```
 
 ## 3. Test it
@@ -40,7 +42,7 @@ $ docker run --log-driver=fluentd -t ubuntu echo "Testing a log message"
 On Fluent Bit container will print to stdout something like this:
 
 ```
-Fluent-Bit v0.13.0
+Fluent Bit v1.0.4
 Copyright (C) Treasure Data
 
 [0] docker.31c94ceb86ca: [1487548735, {"container_id"=>"31c94ceb86cae7055564eb4d65cd2e2897addd252fe6b86cd11bddd70a871c08", "container_name"=>"/admiring_shannon", "source"=>"stdout","}]og"=>"Testing a log message


### PR DESCRIPTION
Hi!

I've added 0.14 and 1.0 branches to the docs.

Also, Section 3 - Test it - is slightly misleading as default configuration doesn't contain Forward input plugin. If it's possible to return the configuration back as on 0.14 branch or add Forward in addition to Cpu plugin, it would be great. I can provide it as a separate pull request if necessary.

Kind regards and thanks for Fluent Bit,
Sergei