### PR TITLE
[arm7/aarch64] Add qemu-static* binaries to the builder

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,12 +1,13 @@
 FROM arm32v7/debian:buster-slim as builder
 
+COPY --from=multiarch/qemu-user-static:x86_64-arm /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.7.0
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
@@ -67,6 +68,8 @@ COPY conf/fluent-bit.conf \
 
 FROM arm32v7/debian:buster-slim
 
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       libssl1.1 \
@@ -78,7 +81,7 @@ RUN apt-get update && \
       ca-certificates
 
 COPY --from=builder /fluent-bit /fluent-bit
-
+RUN rm /usr/bin/qemu-arm-static
 #
 EXPOSE 2020
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,12 +1,13 @@
 FROM arm64v8/debian:buster-slim as builder
 
+COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.7.0
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
@@ -63,6 +64,8 @@ COPY conf/fluent-bit.conf \
      /fluent-bit/etc/
 
 FROM arm64v8/debian:buster-slim
+COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       libssl1.1 \
@@ -74,6 +77,8 @@ RUN apt-get update && \
       ca-certificates
 
 COPY --from=builder /fluent-bit /fluent-bit
+
+RUN rm /usr/bin/qemu-aarch64-static
 
 #
 EXPOSE 2020

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -6,7 +6,6 @@ ENV FLB_MINOR 7
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.7.0
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/

--- a/Dockerfile.x86_64-debug
+++ b/Dockerfile.x86_64-debug
@@ -6,7 +6,6 @@ ENV FLB_MINOR 7
 ENV FLB_PATCH 0
 ENV FLB_VERSION 1.7.0
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/


### PR DESCRIPTION
* With this patch is possible to build the aarch64 and armv7 images in a x86 host by adding the qemu
static binary in the build image, subsequently removing it to save the disk space.
* Removed the ADD source entry (not required)
* Renamed the x86 .debug dockerfile to -debug (to ease automation)

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>