### PR TITLE
[docker] Use cc-debian11 for distroless base image

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -61,8 +61,8 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM gcr.io/distroless/cc-debian10
-MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
+FROM gcr.io/distroless/cc-debian11
+LABEL org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>"
 LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
 
 # Copy certificates

--- a/Dockerfile.x86_64-debug
+++ b/Dockerfile.x86_64-debug
@@ -67,8 +67,8 @@ COPY --from=amd64/busybox:1.31.1 /bin/busybox /bin/busybox
 RUN chmod 555 /bin/busybox && \
     /bin/busybox --install -s /usr/local/bin
 
-FROM gcr.io/distroless/cc-debian10
-MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
+FROM gcr.io/distroless/cc-debian11
+LABEL org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>"
 LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
 
 # Copy certificates

--- a/Dockerfile.x86_64-master
+++ b/Dockerfile.x86_64-master
@@ -49,8 +49,8 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM gcr.io/distroless/cc-debian10
-MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
+FROM gcr.io/distroless/cc-debian11
+LABEL org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>"
 LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
 
 # Copy certificates


### PR DESCRIPTION
Using `gcr.io/distroless/cc-debian11` instead of `gcr.io/distroless/cc-debian10`
Using `LABEL` instead of `MAINTAINER` (deprecated)