### PR TITLE
1.8: update systemd libs and align with Fluent Bit repo

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.7.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.7.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.8.9
+ENV FLB_PATCH 10
+ENV FLB_VERSION 1.8.10
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.7.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.7.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.7.0
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.7.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.8.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.8.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.8.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.8.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -2,9 +2,9 @@ FROM arm32v7/debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
-ENV FLB_MINOR 7
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.7.9
+ENV FLB_MINOR 8
+ENV FLB_PATCH 0
+ENV FLB_VERSION 1.8.0
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,19 +1,21 @@
 FROM arm32v7/debian:buster-slim as builder
 
+COPY --from=multiarch/qemu-user-static:x86_64-arm /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 11
-ENV FLB_VERSION 1.8.11
+ENV FLB_PATCH 12
+ENV FLB_VERSION 1.8.12
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -24,14 +26,13 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
     flex \
     bison \
     openssl \
-    libatomic1 \
     && c_rehash \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
     && cd tmp/ && mkdir fluent-bit \
@@ -68,19 +69,22 @@ COPY conf/fluent-bit.conf \
 
 FROM arm32v7/debian:buster-slim
 
-RUN apt-get update && \
+COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       libssl1.1 \
       libsasl2-2 \
       pkg-config \
       libpq5 \
-      libsystemd0 \
+      libsystemd0/buster-backports \
       zlib1g \
       ca-certificates \
       libatomic1
 
 COPY --from=builder /fluent-bit /fluent-bit
-
+RUN rm /usr/bin/qemu-arm-static
 #
 EXPOSE 2020
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.7.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.7.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.8.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.8.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -31,6 +31,7 @@ RUN apt-get update && \
     flex \
     bison \
     openssl \
+    libatomic1 \
     && c_rehash \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
     && cd tmp/ && mkdir fluent-bit \
@@ -75,7 +76,8 @@ RUN apt-get update && \
       libpq5 \
       libsystemd0 \
       zlib1g \
-      ca-certificates
+      ca-certificates \
+      libatomic1
 
 COPY --from=builder /fluent-bit /fluent-bit
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.8.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.8.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.7.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.7.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 1
-ENV FLB_VERSION 1.8.1
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.8.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.7.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.7.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.8.0
+ENV FLB_PATCH 1
+ENV FLB_VERSION 1.8.1
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.8.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.8.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.8.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.8.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.8.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.8.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.7.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.7.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 10
-ENV FLB_VERSION 1.8.10
+ENV FLB_PATCH 11
+ENV FLB_VERSION 1.8.11
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -3,8 +3,8 @@ FROM arm32v7/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.7.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.7.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.7.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.7.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.8.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.8.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.8.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.8.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.8.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.8.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.8.9
+ENV FLB_PATCH 10
+ENV FLB_VERSION 1.8.10
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.7.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.7.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 10
-ENV FLB_VERSION 1.8.10
+ENV FLB_PATCH 11
+ENV FLB_VERSION 1.8.11
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.7.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.7.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.8.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.8.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.8.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.8.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.7.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.7.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,19 +1,19 @@
-FROM arm64v8/debian:buster-slim as builder
+FROM --platform=linux/arm64 debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 11
-ENV FLB_VERSION 1.8.11
+ENV FLB_PATCH 12
+ENV FLB_VERSION 1.8.12
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -24,7 +24,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -62,20 +62,48 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM arm64v8/debian:buster-slim
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      libssl1.1 \
-      libsasl2-2 \
-      pkg-config \
-      libpq5 \
-      libsystemd0 \
-      zlib1g \
-      ca-certificates
+FROM --platform=linux/arm64 debian:buster-slim
+LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
+LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.8"
 
+# Copy certificates
+COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
+COPY --from=builder /etc/ssl/ /etc/ssl/
+
+# SSL stuff
+COPY --from=builder /usr/lib/aarch64-linux-gnu/*sasl* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libz* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libz* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
+
+# These below are all needed for systemd
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libsystemd* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/liblzma.so* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/liblz4.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libgcrypt.so* /lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libgpg-error.so* /lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libpq.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgssapi* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libldap* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libkrb* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libk5crypto* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/liblber* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgnutls* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libp11-kit* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libidn2* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libunistring* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libtasn1* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libnettle* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libhogweed* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgmp* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libffi* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libcom_err* /lib/aarch64-linux-gnu/
+COPY --from=builder /lib/aarch64-linux-gnu/libkeyutils* /lib/aarch64-linux-gnu/
+
+# Build artifact
 COPY --from=builder /fluent-bit /fluent-bit
 
-#
 EXPOSE 2020
 
 # Entry point

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.7.0
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.7.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.7.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.7.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.8.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.8.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.7.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.7.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 1
-ENV FLB_VERSION 1.8.1
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.8.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -2,9 +2,9 @@ FROM arm64v8/debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
-ENV FLB_MINOR 7
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.7.9
+ENV FLB_MINOR 8
+ENV FLB_PATCH 0
+ENV FLB_VERSION 1.8.0
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.7.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.7.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.8.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.8.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -3,8 +3,8 @@ FROM arm64v8/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.8.0
+ENV FLB_PATCH 1
+ENV FLB_VERSION 1.8.1
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.7.0
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.7.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.8.0
+ENV FLB_PATCH 1
+ENV FLB_VERSION 1.8.1
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.8.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.8.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.8.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.8.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.8.9
+ENV FLB_PATCH 10
+ENV FLB_VERSION 1.8.10
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.7.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.7.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.8.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.8.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.7.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.7.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.7.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.7.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.8.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.8.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.7.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.7.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.8.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.8.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 10
-ENV FLB_VERSION 1.8.10
+ENV FLB_PATCH 11
+ENV FLB_VERSION 1.8.11
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.7.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.7.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.8.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.8.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -2,9 +2,9 @@ FROM amd64/debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
-ENV FLB_MINOR 7
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.7.9
+ENV FLB_MINOR 8
+ENV FLB_PATCH 0
+ENV FLB_VERSION 1.8.0
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.7.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.7.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.7.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.7.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.8.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.8.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,8 +3,8 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 1
-ENV FLB_VERSION 1.8.1
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.8.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -3,17 +3,17 @@ FROM amd64/debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 11
-ENV FLB_VERSION 1.8.11
+ENV FLB_PATCH 12
+ENV FLB_VERSION 1.8.12
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -24,7 +24,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -78,7 +78,7 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-g
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
-COPY --from=builder /lib/x86_64-linux-gnu/libsystemd* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,16 +3,16 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 11
-ENV FLB_VERSION 1.8.11
+ENV FLB_PATCH 12
+ENV FLB_VERSION 1.8.12
 
-ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
 RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
@@ -24,7 +24,7 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev \
+    libsystemd-dev/buster-backports \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
@@ -83,7 +83,7 @@ COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
 # These below are all needed for systemd
-COPY --from=builder /lib/x86_64-linux-gnu/libsystemd* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 10
-ENV FLB_VERSION 1.8.10
+ENV FLB_PATCH 11
+ENV FLB_VERSION 1.8.11
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 1
-ENV FLB_VERSION 1.8.1
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.8.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.8.0
+ENV FLB_PATCH 1
+ENV FLB_VERSION 1.8.1
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.8.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.8.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.8.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.8.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.8.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.8.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.8.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.8.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.8.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.8.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.8.9
+ENV FLB_PATCH 10
+ENV FLB_VERSION 1.8.10
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 5
-ENV FLB_VERSION 1.7.5
+ENV FLB_PATCH 6
+ENV FLB_VERSION 1.7.6
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -2,9 +2,9 @@ FROM debian:buster-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
-ENV FLB_MINOR 7
-ENV FLB_PATCH 9
-ENV FLB_VERSION 1.7.9
+ENV FLB_MINOR 8
+ENV FLB_PATCH 0
+ENV FLB_VERSION 1.8.0
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 0
-ENV FLB_VERSION 1.7.0
+ENV FLB_PATCH 2
+ENV FLB_VERSION 1.7.2
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 2
-ENV FLB_VERSION 1.7.2
+ENV FLB_PATCH 3
+ENV FLB_VERSION 1.7.3
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.7.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.7.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 8
-ENV FLB_VERSION 1.7.8
+ENV FLB_PATCH 9
+ENV FLB_VERSION 1.7.9
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 3
-ENV FLB_VERSION 1.7.3
+ENV FLB_PATCH 4
+ENV FLB_VERSION 1.7.4
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 6
-ENV FLB_VERSION 1.7.6
+ENV FLB_PATCH 7
+ENV FLB_VERSION 1.7.7
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 7
-ENV FLB_VERSION 1.8.7
+ENV FLB_PATCH 8
+ENV FLB_VERSION 1.8.8
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 7
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.7.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.7.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -3,8 +3,8 @@ FROM debian:buster-slim as builder
 # Fluent Bit version
 ENV FLB_MAJOR 1
 ENV FLB_MINOR 8
-ENV FLB_PATCH 4
-ENV FLB_VERSION 1.8.4
+ENV FLB_PATCH 5
+ENV FLB_VERSION 1.8.5
 
 ADD source /
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz


### PR DESCRIPTION
Include merged changes from https://github.com/fluent/fluent-bit/pull/4567