### PR TITLE
dockerfiles: update to 1.8

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,6 +1,7 @@
-FROM arm32v7/debian:buster-slim as builder
+FROM multiarch/qemu-user-static:x86_64-arm as qemu
+FROM arm32v7/debian:bullseye-slim as builder
 
-COPY --from=multiarch/qemu-user-static:x86_64-arm /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -10,12 +11,12 @@ ENV FLB_VERSION 1.8.12
 
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
 
 ENV DEBIAN_FRONTEND noninteractive
-
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
-    apt-get update && \
+WORKDIR /tmp/fluent-bit/
+# hadolint ignore=DL3008
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -26,18 +27,18 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev/buster-backports \
+    libsystemd-dev \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
     flex \
     bison \
     openssl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && c_rehash \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
-    && cd tmp/ && mkdir fluent-bit \
-    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
-    && cd fluent-bit/build/ \
+    && tar zxfv /tmp/fluent-bit.tar.gz -C /tmp/fluent-bit --strip-components=1 \
     && rm -rf /tmp/fluent-bit/build/*
 
 WORKDIR /tmp/fluent-bit/build/
@@ -67,21 +68,24 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM arm32v7/debian:buster-slim
+FROM arm32v7/debian:bullseye-slim
+LABEL description="Fluent Bit docker image" vendor="Fluent Organization" version="1.8.12" author="Eduardo Silva <eduardo@calyptia.com>"
 
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
-
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
-    apt-get update && \
+# hadolint ignore=DL3008
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       libssl1.1 \
       libsasl2-2 \
       pkg-config \
       libpq5 \
-      libsystemd0/buster-backports \
+      libsystemd0 \
       zlib1g \
       ca-certificates \
-      libatomic1
+      libatomic1 \
+      libgcrypt20 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /fluent-bit /fluent-bit
 RUN rm /usr/bin/qemu-arm-static

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 debian:buster-slim as builder
+FROM arm64v8/debian:bullseye-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -12,8 +12,9 @@ RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-mas
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
-    apt-get update && \
+WORKDIR /tmp/fluent-bit/
+# hadolint ignore=DL3008
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -24,16 +25,16 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev/buster-backports \
+    libsystemd-dev \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
     flex \
     bison \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
-    && cd tmp/ && mkdir fluent-bit \
-    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
-    && cd fluent-bit/build/ \
+    && tar zxfv /tmp/fluent-bit.tar.gz -C /tmp/fluent-bit --strip-components=1 \
     && rm -rf /tmp/fluent-bit/build/*
 
 WORKDIR /tmp/fluent-bit/build/
@@ -62,9 +63,8 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM --platform=linux/arm64 debian:buster-slim
-LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
-LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.8"
+FROM arm64v8/debian:bullseye-slim
+LABEL description="Fluent Bit docker image" vendor="Fluent Organization" version="1.8.12" author="Eduardo Silva <eduardo@calyptia.com>"
 
 # Copy certificates
 COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
@@ -76,6 +76,7 @@ COPY --from=builder /usr/lib/aarch64-linux-gnu/libz* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /lib/aarch64-linux-gnu/libz* /lib/aarch64-linux-gnu/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux-gnu/
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgcrypt.so* /usr/lib/aarch64-linux-gnu/
 
 # These below are all needed for systemd
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libsystemd* /usr/lib/aarch64-linux-gnu/

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,4 +1,4 @@
-FROM amd64/debian:bullseye-slim as builder
+FROM debian:bullseye-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -65,7 +65,7 @@ COPY conf/fluent-bit.conf \
 
 # hadolint ignore=DL3006
 FROM gcr.io/distroless/cc-debian11
-LABEL description="Fluent Bit docker image" vendor="Fluent Organization" version="1.9.0" author="Eduardo Silva <eduardo@calyptia.com>"
+LABEL description="Fluent Bit docker image" vendor="Fluent Organization" version="1.8.12" author="Eduardo Silva <eduardo@calyptia.com>"
 
 # Copy certificates
 COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
@@ -77,14 +77,13 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgcrypt.so* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libgcrypt.so* /lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgcrypt.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libpcre.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libgpg-error.so* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libpq.so* /usr/lib/x86_64-linux-gnu/

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,4 +1,4 @@
-FROM amd64/debian:buster-slim as builder
+FROM amd64/debian:bullseye-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -8,12 +8,13 @@ ENV FLB_VERSION 1.8.12
 
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && \
-    apt-get update && \
+WORKDIR /tmp/fluent-bit/
+# hadolint ignore=DL3008
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -24,16 +25,16 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev/buster-backports \
+    libsystemd-dev \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
     flex \
     bison \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
-    && cd tmp/ && mkdir fluent-bit \
-    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
-    && cd fluent-bit/build/ \
+    && tar zxfv /tmp/fluent-bit.tar.gz -C /tmp/fluent-bit --strip-components=1 \
     && rm -rf /tmp/fluent-bit/build/*
 
 WORKDIR /tmp/fluent-bit/build/
@@ -48,7 +49,7 @@ RUN cmake -DFLB_RELEASE=On \
           -DFLB_OUT_KAFKA=On \
           -DFLB_OUT_PGSQL=On ..
 
-RUN make -j $(getconf _NPROCESSORS_ONLN)
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Configuration files
@@ -62,9 +63,9 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-FROM gcr.io/distroless/cc-debian10
-MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
-LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
+# hadolint ignore=DL3006
+FROM gcr.io/distroless/cc-debian11
+LABEL description="Fluent Bit docker image" vendor="Fluent Organization" version="1.9.0" author="Eduardo Silva <eduardo@calyptia.com>"
 
 # Copy certificates
 COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
@@ -76,6 +77,7 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgcrypt.so* /usr/lib/x86_64-linux-gnu/
 
 # These below are all needed for systemd
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/

--- a/Dockerfile.x86_64.debug
+++ b/Dockerfile.x86_64.debug
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as builder
+FROM amd64/debian:bullseye-slim as builder
 
 # Fluent Bit version
 ENV FLB_MAJOR 1
@@ -8,11 +8,12 @@ ENV FLB_VERSION 1.8.12
 
 ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
 ENV FLB_SOURCE $FLB_TARBALL
-RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit/
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
+WORKDIR /tmp/fluent-bit/
+# hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
@@ -24,24 +25,23 @@ RUN apt-get update && \
     libssl-dev \
     libsasl2-dev \
     pkg-config \
-    libsystemd-dev/buster-backports \
+    libsystemd-dev \
     zlib1g-dev \
     libpq-dev \
     postgresql-server-dev-all \
     flex \
     bison \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
-    && cd tmp/ && mkdir fluent-bit \
-    && tar zxfv fluent-bit.tar.gz -C ./fluent-bit --strip-components=1 \
-    && cd fluent-bit/build/ \
+    && tar zxfv /tmp/fluent-bit.tar.gz -C /tmp/fluent-bit --strip-components=1 \
     && rm -rf /tmp/fluent-bit/build/*
 
 WORKDIR /tmp/fluent-bit/build/
-RUN cmake -DFLB_DEBUG=On \
+RUN cmake -DFLB_RELEASE=On \
           -DFLB_TRACE=Off \
           -DFLB_JEMALLOC=On \
           -DFLB_TLS=On \
-          -DFLB_HTTP_CLIENT_DEBUG=On \
           -DFLB_SHARED_LIB=Off \
           -DFLB_EXAMPLES=Off \
           -DFLB_HTTP_SERVER=On \
@@ -49,7 +49,7 @@ RUN cmake -DFLB_DEBUG=On \
           -DFLB_OUT_KAFKA=On \
           -DFLB_OUT_PGSQL=On ..
 
-RUN make -j $(getconf _NPROCESSORS_ONLN)
+RUN make -j "$(getconf _NPROCESSORS_ONLN)"
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Configuration files
@@ -63,55 +63,29 @@ COPY conf/fluent-bit.conf \
      conf/plugins.conf \
      /fluent-bit/etc/
 
-COPY --from=amd64/busybox:1.31.1 /bin/busybox /bin/busybox
+# hadolint ignore=DL3006
+FROM debian:bullseye-slim
+LABEL description="Fluent Bit debug docker image" vendor="Fluent Organization" version="1.8.12" author="Eduardo Silva <eduardo@calyptia.com>"
 
-RUN chmod 555 /bin/busybox && \
-    /bin/busybox --install -s /usr/local/bin
-
-FROM gcr.io/distroless/cc-debian10
-MAINTAINER Eduardo Silva <eduardo@treasure-data.com>
-LABEL Description="Fluent Bit docker image" Vendor="Fluent Organization" Version="1.1"
-
-# Copy certificates
-COPY --from=builder /usr/share/ca-certificates/  /usr/share/ca-certificates/
-COPY --from=builder /etc/ssl/ /etc/ssl/
-
-# SSL stuff
-COPY --from=builder /usr/lib/x86_64-linux-gnu/*sasl* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libz* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libz* /lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
-# These below are all needed for systemd
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libsystemd* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libselinux.so* /lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/liblzma.so* /lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/liblz4.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libgcrypt.so* /lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libpcre.so* /lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libgpg-error.so* /lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libpq.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgssapi* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libldap* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libkrb* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libk5crypto* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/liblber* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgnutls* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libp11-kit* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libidn2* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libunistring* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libtasn1* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libnettle* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libhogweed* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgmp* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libffi* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libcom_err* /lib/x86_64-linux-gnu/
-COPY --from=builder /lib/x86_64-linux-gnu/libkeyutils* /lib/x86_64-linux-gnu/
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libssl1.1 \
+      libsasl2-2 \
+      pkg-config \
+      libpq5 \
+      libsystemd0 \
+      zlib1g \
+      ca-certificates \
+      libatomic1 \
+      libgcrypt20 \
+      bash gdb valgrind build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /fluent-bit /fluent-bit
 
-COPY --from=builder /usr/local/bin/ /usr/local/bin/
-COPY --from=builder /bin/busybox /bin/
+EXPOSE 2020
 
 # Entry point
 CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/README.md
+++ b/README.md
@@ -1,58 +1,44 @@
 # Fluent Bit Docker Image
 
-[Fluent Bit](https://fluentbit.io) container images are available on Docker Hub ready for production usage. Our stable images are based in [Distroless](https://github.com/GoogleContainerTools/distroless) focusing on security containing just the Fluent Bit binary, minimal system libraries and basic configuration.
+[Fluent Bit](https://fluentbit.io) container images are available on Docker Hub ready for production usage.
 
-Optionally, we provide debug images which contains Busybox that can be used to troubleshoot or testing purposes.
+The stable AMD64 images are based on [Distroless](https://github.com/GoogleContainerTools/distroless) focusing on security containing just the Fluent Bit binary, minimal system libraries and basic configuration.
 
-For a detailed list of Tags and versions available, please refer to the the official documentation:
+Optionally, we provide debug images which contain shells and tooling that can be used to troubleshoot or for testing purposes.
 
-https://docs.fluentbit.io/manual/installation/docker
+There are also images for ARM32 and ARM64 architectures but no debug versions of these.
 
+For a detailed list of installation, usage and versions available, please refer to the the official documentation: https://docs.fluentbit.io/manual/installation/docker
 
+## Build and test
 
-## 1. Checkout Branch
-
-Fluent Bit Dockerfiles are located in separated branches with proper tags:
-
-| Branch | Tags Available                                               |
-| ------ | ------------------------------------------------------------ |
-| 1.0    | 1.0, 1.0-debug, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.3-debug, 1.0.4, 1.0.4-debug |
-| 0.14   | 0.14, 0.14.0, 0.14.1, 0.14.2, 0.14.3, 0.14.4, 0.14.5, 0.14.6, 0.14.7, 0.14.8, 0.14.9 |
-| 0.13   | 0.13, 0.13.0, 0.13.1, 0.13.2, 0.13.3, 0.13.4, 0.13.5, 0.13.6, 0.13.7, 0.13.8 |
-| 0.12   | 0.12, 0.12.19, 0.12.18, 0.12.17, 0.12.16, 0.12.15, 0.12.14, 0.12.13, 0.12.12, 0.12.11, 0.12.10, 0.12.9, 0.12.8, 0.12.7, 0.12.6, 0.12.5, 0.12.4, 0.12.3, 0.12.2, 0.12.1, 0.12.0 |
-
-## 2. Build image
-
-Use `docker build` command to build the image. This example names the image "fluent-bit:latest":
-
+1. Checkout the branch you want, e.g. 1.8 for 1.8.X containers.
+2. Build the container image using the appropriate Dockerfile in this directory.
 ```
-$ docker build -t fluent/fluent-bit:1.0 ./
+$ docker build -t fluent/fluent-bit -f Dockerfile.x86_64 .
+```
+3. Test the container.
+```
+$ docker run --rm -it fluent/fluent-bit:latest
 ```
 
-## 3. Test it
-
-Once the image is built, it's ready to run:
+By default, the configuration uses the CPU input plugin and the stdout output plugin which means you should see regular output in the log showing the CPU loading.
 
 ```
-docker run -p 127.0.0.1:24224:24224 fluent/fluent-bit:latest
+Fluent Bit v1.8.11
+* Copyright (C) 2019-2021 The Fluent Bit Authors
+* Copyright (C) 2015-2018 Treasure Data
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+[2022/01/13 14:48:44] [ info] [engine] started (pid=1)
+[2022/01/13 14:48:44] [ info] [storage] version=1.1.5, initializing...
+[2022/01/13 14:48:44] [ info] [storage] in-memory
+[2022/01/13 14:48:44] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
+[2022/01/13 14:48:44] [ info] [cmetrics] version=0.2.2
+[2022/01/13 14:48:44] [ info] [sp] stream processor started
+[0] cpu.local: [1642085324.503383520, {"cpu_p"=>0.437500, "user_p"=>0.250000, "system_p"=>0.187500, "cpu0.p_cpu"=>0.000000, "cpu0.p_user"=>0.000000, "cpu0.p_system"=>0.000000, "cpu1.p_cpu"=>0.000000, "cpu1.p_user"=>0.000000, "cpu1.p_system"=>0.000000, "cpu2.p_cpu"=>1.000000, "cpu2.p_user"=>1.000000, "cpu2.p_system"=>0.000000, "cpu3.p_cpu"=>1.000000, "cpu3.p_user"=>1.000000, "cpu3.p_system"=>0.000000, "cpu4.p_cpu"=>1.000000, "cpu4.p_user"=>1.000000, "cpu4.p_system"=>0.000000, "cpu5.p_cpu"=>1.000000, "cpu5.p_user"=>0.000000, "cpu5.p_system"=>1.000000, "cpu6.p_cpu"=>0.000000, "cpu6.p_user"=>0.000000, "cpu6.p_system"=>0.000000, "cpu7.p_cpu"=>0.000000, "cpu7.p_user"=>0.000000, "cpu7.p_system"=>0.000000, "cpu8.p_cpu"=>2.000000, "cpu8.p_user"=>1.000000, "cpu8.p_system"=>1.000000, "cpu9.p_cpu"=>1.000000, "cpu9.p_user"=>1.000000, "cpu9.p_system"=>0.000000, "cpu10.p_cpu"=>0.000000, "cpu10.p_user"=>0.000000, "cpu10.p_system"=>0.000000, "cpu11.p_cpu"=>0.000000, "cpu11.p_user"=>0.000000, "cpu11.p_system"=>0.000000, "cpu12.p_cpu"=>0.000000, "cpu12.p_user"=>0.000000, "cpu12.p_system"=>0.000000, "cpu13.p_cpu"=>0.000000, "cpu13.p_user"=>0.000000, "cpu13.p_system"=>0.000000, "cpu14.p_cpu"=>2.000000, "cpu14.p_user"=>1.000000, "cpu14.p_system"=>1.000000, "cpu15.p_cpu"=>0.000000, "cpu15.p_user"=>0.000000, "cpu15.p_system"=>0.000000}]
 ```
-
-By default, the configuration set a listener on TCP port 24224 through Forward protocol and prints to the standard output interface each message. So this can be used to forward Docker log messages from one container to the Fluent Bit image, e.g:
-
-```
-$ docker run --log-driver=fluentd -t ubuntu echo "Testing a log message"
-```
-
-
-On Fluent Bit container will print to stdout something like this:
-
-```
-Fluent Bit v1.0.4
-Copyright (C) Treasure Data
-
-[0] docker.31c94ceb86ca: [1487548735, {"container_id"=>"31c94ceb86cae7055564eb4d65cd2e2897addd252fe6b86cd11bddd70a871c08", "container_name"=>"/admiring_shannon", "source"=>"stdout","}]og"=>"Testing a log message
-```
-
 ## Contact
 
 Feel free to join us on our Mailing List or IRC:


### PR DESCRIPTION
Merged changes from Fluent Bit repo.
Signed-off-by: Patrick Stephens <pat@calyptia.com>

Tested by building v1.8.11 source and running each architecture to confirm:
```
$ docker buildx build --load --platform=linux/amd64 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz -t fb-test:1.8.11-x86_64 -f ./Dockerfile.x86_64 .
$ docker run --rm -it fb-test:1.8.11-x86_64
Fluent Bit v1.8.11
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/01/21 15:38:14] [ info] [engine] started (pid=1)
[2022/01/21 15:38:14] [ info] [storage] version=1.1.5, initializing...
[2022/01/21 15:38:14] [ info] [storage] in-memory
[2022/01/21 15:38:14] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2022/01/21 15:38:14] [ info] [cmetrics] version=0.2.2
[2022/01/21 15:38:14] [ info] [sp] stream processor started
[0] cpu.local: [1642779494.992031190, {"cpu_p"=>0.000000,
...
$ docker buildx build --load --platform=linux/arm64 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz -t fb-test:1.8.11-arm64 -f ./Dockerfile.arm64v8 .
$ docker run --rm -it fb-test:1.8.11-arm64
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested
Fluent Bit v1.8.11
...
$ docker buildx build --load --platform=linux/arm32/v7 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz -t fb-test:1.8.11-arm32 -f ./Dockerfile.arm32v7 .
$ docker run --rm -it fb-test:1.8.11-arm32
WARNING: The requested image's platform (linux/arm32/v7) does not match the detected host platform (linux/amd64) and no specific platform was requested
Fluent Bit v1.8.11
...
$ docker buildx build --load --platform=linux/amd64 --build-arg FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v1.8.11.tar.gz -t fb-test:1.8.11-x86_64-debug -f ./Dockerfile.x86_64.debug .
$  docker run --rm -it fb-test:1.8.11-x86_64-debug
Fluent Bit v1.8.11
...
$ docker run --rm -it fb-test:1.8.11-x86_64-debug sh
# ls
bin  boot  dev	etc  fluent-bit  home  lib  lib64  media  mnt  opt  proc  root	run  sbin  srv	sys  tmp  usr  var
# 
```

To set up QEMU & buildx:
```bash
# https://askubuntu.com/a/1369504 
sudo add-apt-repository ppa:jacob/virtualisation 
sudo apt-get update && sudo apt-get install qemu qemu-user qemu-user-static

# https://docs.docker.com/buildx/working-with-buildx/#install 
wget https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64 
mv buildx-v0.7.1.linux-amd64 ~/.docker/cli-plugins/docker-buildx
chmod a+x ~/.docker/cli-plugins/docker-buildx

# https://stackoverflow.com/a/60667468 
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
docker buildx rm builder
docker buildx create --name builder --use
docker buildx inspect --bootstrap
```