### PR TITLE
ci: build images in GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github/
+ci/
+hooks/
+LICENSE
+Makefile
+README.md

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -1,0 +1,43 @@
+name: Release builds
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-sumo-[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-sumo-[0-9]+-alpha.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-sumo-[0-9]+-beta.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-sumo-[0-9]+-rc.[0-9]+'
+
+jobs:
+  build-push-arm32v7:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push arm32v7
+        run: ./ci/build-push-arm32v7.sh
+
+  build-push-arm64v8:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push arm64v8
+        run: ./ci/build-push-arm64v8.sh
+
+  build-push-x86_64:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push x86_64
+        run: ./ci/build-push-x86_64.sh
+  
+  push-multiplatform-manifest:
+    runs-on: ubuntu-20.04
+    needs:
+      - build-push-arm32v7
+      - build-push-arm64v8
+      - build-push-x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - name: Push multiplatform manifest
+        run: ./ci/push-multiplatform-manifest.sh
+

--- a/ci/build-push-all.sh
+++ b/ci/build-push-all.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+DOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+source "$DOT/variables.sh"
+
+"$DOT/patch-fluent-bit-version.sh"
+
+"$DOT/build-push-${amd64_arch}.sh" &
+readonly amd64_pid=$!
+
+"$DOT/build-push-${arm_arch}.sh" &
+readonly arm_pid=$!
+
+"$DOT/build-push-${arm64_arch}.sh" &
+readonly arm64_pid=$!
+
+wait $amd64_pid
+wait $arm_pid
+wait $arm64_pid
+
+"$DOT/push-multiplatform-manifest.sh"

--- a/ci/build-push-arm32v7.sh
+++ b/ci/build-push-arm32v7.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+if ! docker buildx ls | grep arm
+then
+    echo "Your Buildx seems to lack ARM architecture support"
+    exit 1
+fi
+
+source "$(dirname "${BASH_SOURCE[0]}")/variables.sh"
+
+docker buildx build \
+    --push \
+    --platform=linux/arm/v7 \
+    --tag "${REPO_URL}:${BUILD_TAG}-${arm_arch}" \
+    --file "Dockerfile.${arm_arch}" \
+    .

--- a/ci/build-push-arm64v8.sh
+++ b/ci/build-push-arm64v8.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+if ! docker buildx ls | grep arm
+then
+    echo "Your Buildx seems to lack ARM architecture support"
+    exit 1
+fi
+
+DOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+source "$DOT/variables.sh"
+
+docker buildx build \
+    --push \
+    --platform=linux/arm64/v8 \
+    --tag "${REPO_URL}:${BUILD_TAG}-${arm64_arch}" \
+    --file "Dockerfile.${arm64_arch}" \
+    .

--- a/ci/build-push-x86_64.sh
+++ b/ci/build-push-x86_64.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/variables.sh"
+
+docker buildx build \
+    --push \
+    --platform=linux/amd64 \
+    --tag "${REPO_URL}:${BUILD_TAG}-${amd64_arch}" \
+    --file "Dockerfile.${amd64_arch}" \
+    .

--- a/ci/get-build-tag.sh
+++ b/ci/get-build-tag.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+BUILD_TAG=$(git describe)
+# Remove the `v` prefix from the tag
+echo "${BUILD_TAG#v}"

--- a/ci/patch-fluent-bit-version.sh
+++ b/ci/patch-fluent-bit-version.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# Patches the Dockerfiles with the Fluent Bit version retrieved from the build tag.
+# It assumes that the Fluent Bit version is the first part of the argument passed into the function.
+# For example, calling `patch_fluent_bit_version "1.2.3-sumo-x.y.z"` will set Fluent Bit version to 1.2.3.
+function patch_fluent_bit_version() {
+    # Remove everything after first `-sumo` (including), e.g. `1.2.3-sumo-1-rc.1` => `1.2.3`
+    fb_version=${1%%-*}
+    # Check that Fluent Bit version is in correct format (SemVer)
+    [[ "$fb_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit 10
+
+    # Remove everything after first dot `.`, e.g. `1.2.3` => `1`
+    fb_major=${fb_version%%.*}
+
+    # Remove everything before first dot `.`, e.g. `1.2.3` => `2.3`
+    fb_minor_patch=${fb_version#*.}
+    # Remove everything after first dot `.`, e.g. `2.3` => `2`
+    fb_minor=${fb_minor_patch%%.*}
+
+    # Remove everything before last dot `.`, e.g. `1.2.3` => `3`
+    fb_patch=${fb_version##*.}
+
+    for arch in $amd64_arch $arm_arch $arm64_arch; do
+        sed -i "s/ENV FLB_MAJOR .*/ENV FLB_MAJOR $fb_major/" "Dockerfile.${arch}"
+        sed -i "s/ENV FLB_MINOR .*/ENV FLB_MINOR $fb_minor/" "Dockerfile.${arch}"
+        sed -i "s/ENV FLB_PATCH .*/ENV FLB_PATCH $fb_patch/" "Dockerfile.${arch}"
+        sed -i "s/ENV FLB_VERSION .*/ENV FLB_VERSION $fb_version/" "Dockerfile.${arch}"
+    done
+}
+
+source "$(dirname "${BASH_SOURCE[0]}")/variables.sh"
+
+patch_fluent_bit_version "${BUILD_TAG}"

--- a/ci/push-multiplatform-manifest.sh
+++ b/ci/push-multiplatform-manifest.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/variables.sh"
+
+docker manifest create --amend \
+    "${REPO_URL}:${BUILD_TAG}" \
+    "${REPO_URL}:${BUILD_TAG}-${amd64_arch}" \
+    "${REPO_URL}:${BUILD_TAG}-${arm_arch}" \
+    "${REPO_URL}:${BUILD_TAG}-${arm64_arch}"
+
+docker manifest push "${REPO_URL}:${BUILD_TAG}"

--- a/ci/variables.sh
+++ b/ci/variables.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+readonly amd64_arch=x86_64
+readonly arm_arch=arm32v7
+readonly arm64_arch=arm64v8
+readonly default_repo_url=public.ecr.aws/sumologic/fluent-bit
+
+REPO_URL=${REPO_URL:-$default_repo_url}
+
+DOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+BUILD_TAG=${BUILD_TAG:-$("$DOT/get-build-tag.sh")}


### PR DESCRIPTION
The `/ci/build-push-multiplatform.sh` script can be used when you want to build all three platform images in parallel on a single machine.

The GitHub Actions workflow `release_builds` uses three separate scripts `/ci/build-push-<platform>.sh` to build image for each platform on a separate runner, and then push the multiplatform image manifest when all images are pushed. These platform-specific scripts can also be used to build all images serially on one machine.